### PR TITLE
fix: align all SEO signals to canonical www host

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,44 +7,38 @@
     <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
     <meta name="theme-color" content="#0f172a" media="(prefers-color-scheme: dark)" />
 
-    <!-- Primary Meta Tags -->
     <title>Federico Bello | Portfolio</title>
     <meta name="description" content="Lead ML Engineer at Tryolabs and Forward Deployed Engineer with LlamaIndex. AI systems, Graph Neural Networks &amp; applied mathematics. Explore Federico Bello's projects and publications." />
     <meta name="author" content="Federico Bello" />
     <meta name="robots" content="index, follow" />
 
-    <!-- Canonical (updated dynamically per route via React) -->
-    <link rel="canonical" href="https://fedebello.com/" />
+    <link rel="canonical" href="https://www.fedebello.com/" />
 
-    <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/me.png" />
 
-    <!-- Open Graph (Facebook, LinkedIn, Slack) -->
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://fedebello.com" />
+    <meta property="og:url" content="https://www.fedebello.com" />
     <meta property="og:title" content="Federico Bello | Portfolio" />
     <meta property="og:description" content="Lead ML Engineer at Tryolabs and Forward Deployed Engineer with LlamaIndex. AI systems, Graph Neural Networks &amp; applied mathematics. Explore Federico Bello's projects and publications." />
-    <meta property="og:image" content="https://fedebello.com/me.png" />
+    <meta property="og:image" content="https://www.fedebello.com/me.png" />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:site_name" content="Federico Bello" />
     <meta property="og:locale" content="en_US" />
 
-    <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="Federico Bello | Portfolio" />
     <meta name="twitter:description" content="Lead ML Engineer at Tryolabs and Forward Deployed Engineer with LlamaIndex. AI systems, Graph Neural Networks &amp; applied mathematics. Explore Federico Bello's projects and publications." />
-    <meta name="twitter:image" content="https://fedebello.com/me.png" />
+    <meta name="twitter:image" content="https://www.fedebello.com/me.png" />
 
-    <!-- Schema.org JSON-LD -->
     <script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Person",
       "name": "Federico Bello",
-      "url": "https://fedebello.com",
-      "image": "https://fedebello.com/me.png",
+      "url": "https://www.fedebello.com",
+      "image": "https://www.fedebello.com/me.png",
       "jobTitle": "Lead Machine Learning Engineer",
       "sameAs": [
         "https://www.linkedin.com/in/federico-bello-/",
@@ -53,7 +47,6 @@
     }
     </script>
 
-    <!-- Fonts -->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -66,7 +59,6 @@
     <script type="module" src="/src/main.tsx"></script>
   </body>
   <script>
-    // Inline theme init to avoid FOUC
     (function () {
       try {
         const stored = localStorage.getItem("theme");

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -14,4 +14,4 @@ Allow: /
 User-agent: anthropic-ai
 Allow: /
 
-Sitemap: https://fedebello.com/sitemap.xml
+Sitemap: https://www.fedebello.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://fedebello.com/</loc>
+    <loc>https://www.fedebello.com/</loc>
     <changefreq>monthly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://fedebello.com/experience</loc>
+    <loc>https://www.fedebello.com/experience</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://fedebello.com/projects</loc>
+    <loc>https://www.fedebello.com/projects</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://fedebello.com/publications</loc>
+    <loc>https://www.fedebello.com/publications</loc>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://fedebello.com/contact</loc>
+    <loc>https://www.fedebello.com/contact</loc>
     <changefreq>yearly</changefreq>
     <priority>0.5</priority>
   </url>

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from "url";
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const root = resolve(__dirname, "..");
-const BASE_URL = "https://fedebello.com";
+const BASE_URL = "https://www.fedebello.com";
 
 const routes = ["/", "/experience", "/projects", "/publications", "/contact"];
 
@@ -38,8 +38,6 @@ const pageMeta = {
 
 const template = readFileSync(resolve(root, "dist/index.html"), "utf-8");
 
-// Keep the raw SPA shell as 404.html so unknown routes hydrate cleanly
-// Add noindex to prevent Google from indexing unknown URLs as duplicates
 const notFoundHtml = template
   .replace(
     '<meta name="robots" content="index, follow" />',

--- a/src/layouts/AppLayout.tsx
+++ b/src/layouts/AppLayout.tsx
@@ -8,7 +8,7 @@ import { RouteProgress } from "@/components/RouteProgress";
 import { Analytics } from "@vercel/analytics/react";
 import { getStructuredData } from "@/seo/structured-data";
 
-const BASE_URL = "https://fedebello.com";
+const BASE_URL = "https://www.fedebello.com";
 
 interface PageMeta {
   title: string;
@@ -75,7 +75,6 @@ export function AppLayout(): JSX.Element {
     }
     canonical.href = location.pathname === "/" ? `${BASE_URL}/` : `${BASE_URL}${location.pathname}`;
 
-    // Inject per-page structured data (JSON-LD)
     document.querySelectorAll("script[data-dynamic-schema]").forEach((el) => el.remove());
     getStructuredData(location.pathname).forEach((schema, i) => {
       const el = document.createElement("script");

--- a/src/seo/structured-data.ts
+++ b/src/seo/structured-data.ts
@@ -7,7 +7,7 @@ import {
 } from "@/projects/data";
 import { experiences } from "@/experience/data";
 
-const BASE_URL = "https://fedebello.com";
+const BASE_URL = "https://www.fedebello.com";
 const AUTHOR = {
   "@type": "Person",
   name: "Federico Bello",


### PR DESCRIPTION
## Problem
The site serves on `www.fedebello.com`, but canonical tags, sitemap, robots and structured data all declared the bare apex `fedebello.com` — which now 308-redirects to www. Crawlers got contradictory canonical signals, blocking indexing (`site:fedebello.com` returned nothing).

## Change
Point every host reference to `https://www.fedebello.com` so the declared canonical matches the host that actually serves 200:
- `index.html` — canonical, og:url, og:image, twitter:image, JSON-LD
- `src/layouts/AppLayout.tsx` — per-route canonical/og `BASE_URL`
- `src/seo/structured-data.ts` — `BASE_URL`
- `scripts/prerender.mjs` — `BASE_URL` (bakes the HTML crawlers see)
- `public/sitemap.xml` — all 5 URLs
- `public/robots.txt` — `Sitemap:` line

Also stripped redundant code/section comments from the touched files.

## Verification
- Live: apex → 308 → www, www → 200
- Build + prerender pass; each route's baked HTML carries the correct per-route `www` canonical; `404.html` stays `noindex`

## Follow-up (manual)
Google Search Console: verify the `www.fedebello.com` property, resubmit `https://www.fedebello.com/sitemap.xml`, and request indexing for the home + 4 routes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)