### PR TITLE
Add ICPRAM 2026 GNN anomaly detection publication

### DIFF
--- a/src/publications/data.ts
+++ b/src/publications/data.ts
@@ -12,6 +12,18 @@ export const publications: ReadonlyArray<Publication> = [
       "In this work we examine the Lattice-Input Discrete-Time Poisson (LIDTP) channel, relevant to DNA storage systems. We analyze communication performance with lattice-constrained inputs under Poisson noise and discuss implications for reliable molecular data storage.",
     link: "https://ieeexplore.ieee.org/document/10619495",
   },
+  {
+    title:
+      "GNNs for Time Series Anomaly Detection: An Open-Source Framework and a Critical Evaluation",
+    venue: "ICPRAM 2026",
+    date: "Mar 2026",
+    location: "Marbella, Spain",
+    authors:
+      "Federico Bello, Gonzalo Chiarlone, Marcelo Fiori, Gastón García González, Federico Larroca",
+    summary:
+      "We present GraGOD, an open-source framework for time series anomaly detection (TSAD) using Graph Neural Networks, designed to support reproducible experimentation across datasets, graph structures, and evaluation strategies. Our critical evaluation shows that GNNs improve both detection performance and interpretability, and that attention-based GNNs remain robust when the graph structure is uncertain or inferred.",
+    link: "https://arxiv.org/abs/2603.09675",
+  },
 ];
 
 export const conferences: ReadonlyArray<ConferenceEntry> = [


### PR DESCRIPTION
## Summary

Adds the GraGOD paper **"GNNs for Time Series Anomaly Detection: An Open-Source Framework and a Critical Evaluation"** to the Publications page. This work was published at **ICPRAM 2026** (15th International Conference on Pattern Recognition Applications and Methods, SciTePress, pp. 53–61), not only as an arXiv preprint.

## Changes

- New entry in `src/publications/data.ts`:
  - **Venue:** ICPRAM 2026 — Marbella, Spain (Mar 2026)
  - **Authors:** Federico Bello, Gonzalo Chiarlone, Marcelo Fiori, Gastón García González, Federico Larroca
  - **Link:** [arXiv 2603.09675](https://arxiv.org/abs/2603.09675)

This is the formal publication behind the GraGOD work already presented as the LANET 2025 talk in the Conferences section. It renders through the existing `PublicationsPage` layout with no component changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmZ4XPrtiYpvZgX7rbURVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmZ4XPrtiYpvZgX7rbURVo)_