### PR TITLE
Sort publications and conferences by date

### DIFF
--- a/src/publications/data.ts
+++ b/src/publications/data.ts
@@ -1,6 +1,33 @@
 import type { ConferenceEntry, Publication } from "@/types/publications";
 
-export const publications: ReadonlyArray<Publication> = [
+const MONTHS = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+/** Turns a "MMM YYYY" date into a sortable month index (higher = more recent). */
+function dateKey(date: string): number {
+  const [month, year] = date.split(" ");
+  const monthIndex = MONTHS.indexOf(month);
+  return Number(year) * 12 + (monthIndex < 0 ? 0 : monthIndex);
+}
+
+/** Sort by date, most recent first. */
+function byDateDesc<T extends { date: string }>(a: T, b: T): number {
+  return dateKey(b.date) - dateKey(a.date);
+}
+
+const publicationEntries: ReadonlyArray<Publication> = [
   {
     title: "The Lattice-Input Discrete-Time Poisson Channel",
     venue: "IEEE - ISIT",
@@ -26,7 +53,11 @@ export const publications: ReadonlyArray<Publication> = [
   },
 ];
 
-export const conferences: ReadonlyArray<ConferenceEntry> = [
+export const publications: ReadonlyArray<Publication> = [
+  ...publicationEntries,
+].sort(byDateDesc);
+
+const conferenceEntries: ReadonlyArray<ConferenceEntry> = [
   {
     event: "LANET 2025",
     date: "Aug 2025",
@@ -38,3 +69,7 @@ export const conferences: ReadonlyArray<ConferenceEntry> = [
     link: "https://lanet2025.uy/",
   },
 ];
+
+export const conferences: ReadonlyArray<ConferenceEntry> = [
+  ...conferenceEntries,
+].sort(byDateDesc);


### PR DESCRIPTION
## Summary

Publications and conferences were rendered in array-insertion order, so the newest entry (ICPRAM 2026) appeared below an older one (ISIT 2024). This sorts both lists chronologically, newest first.

## Changes

- `src/publications/data.ts`: added a small `dateKey` parser for the `"MMM YYYY"` format and a `byDateDesc` comparator, and export both `publications` and `conferences` already sorted.
- Sorting happens at the data source, so every consumer (the Publications page and the SEO structured data) stays consistent, and future entries land in the right place without manual reordering.

No component or type changes needed; `tsc -b` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QmZ4XPrtiYpvZgX7rbURVo

---
_Generated by [Claude Code](https://claude.ai/code/session_01QmZ4XPrtiYpvZgX7rbURVo)_